### PR TITLE
Pre-Push git hook

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,5 @@
+[hooks]
+pre-push = "cargo fmt --all -- --check --color always"
+
+[logging]
+verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ serde_path_to_error = "0.1.16"
 percent-encoding = "2.3.1"
 hex = "0.4.3"
 itertools = "0.13.0"
+
+[dev-dependencies]
+rusty-hook = "0.11.2"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/middleware/authentication.rs
+++ b/src/api/middleware/authentication.rs
@@ -1,10 +1,10 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use poem::{Endpoint, http::StatusCode, Middleware, Request};
+use poem::{http::StatusCode, Endpoint, Middleware, Request};
 use sqlx::MySqlPool;
 
 use crate::{

--- a/src/api/middleware/current_user.rs
+++ b/src/api/middleware/current_user.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/middleware/mod.rs
+++ b/src/api/middleware/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use poem::{
-    EndpointExt,
-    IntoResponse,
     listener::TcpListener,
-    middleware::{NormalizePath, TrailingSlash}, Route, Server, web::Json,
+    middleware::{NormalizePath, TrailingSlash},
+    web::Json,
+    EndpointExt, IntoResponse, Route, Server,
 };
 use serde_json::json;
 use sqlx::MySqlPool;

--- a/src/api/routes/auth/login.rs
+++ b/src/api/routes/auth/login.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/auth/mod.rs
+++ b/src/api/routes/auth/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/auth/register.rs
+++ b/src/api/routes/auth/register.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/channels/followers.rs
+++ b/src/api/routes/channels/followers.rs
@@ -1,16 +1,16 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    AddFollowingChannelSchema, FollowedChannel, jwt::Claims, Snowflake, WebhookType,
+    jwt::Claims, AddFollowingChannelSchema, FollowedChannel, Snowflake, WebhookType,
 };
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/invites.rs
+++ b/src/api/routes/channels/invites.rs
@@ -1,13 +1,13 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{CreateChannelInviteSchema, Snowflake};
 use chorus::types::jwt::Claims;
-use poem::{handler, IntoResponse};
+use chorus::types::{CreateChannelInviteSchema, Snowflake};
 use poem::web::{Data, Json, Path};
+use poem::{handler, IntoResponse};
 use sqlx::MySqlPool;
 
 use crate::database::entities::Channel;

--- a/src/api/routes/channels/messages/bulk_delete.rs
+++ b/src/api/routes/channels/messages/bulk_delete.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{Rights, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/messages/id/ack.rs
+++ b/src/api/routes/channels/messages/id/ack.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use serde_json::json;
 use sqlx::MySqlPool;

--- a/src/api/routes/channels/messages/id/crosspost.rs
+++ b/src/api/routes/channels/messages/id/crosspost.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, MessageSendSchema, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/messages/id/mod.rs
+++ b/src/api/routes/channels/messages/id/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, MessageModifySchema, Rights, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/messages/id/reactions.rs
+++ b/src/api/routes/channels/messages/id/reactions.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, PartialEmoji, Reaction, ReactionQuerySchema, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
-    Response, web::{Data, Json, Path, Query},
+    web::{Data, Json, Path, Query},
+    IntoResponse, Response,
 };
 use reqwest::StatusCode;
 use sqlx::MySqlPool;

--- a/src/api/routes/channels/messages/mod.rs
+++ b/src/api/routes/channels/messages/mod.rs
@@ -1,17 +1,17 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    GetChannelMessagesSchema, jwt::Claims, MessageSendSchema,
-    MessageType, Rights, Snowflake, types::guild_configuration::GuildFeatures,
+    jwt::Claims, types::guild_configuration::GuildFeatures, GetChannelMessagesSchema,
+    MessageSendSchema, MessageType, Rights, Snowflake,
 };
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/mod.rs
+++ b/src/api/routes/channels/mod.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{ChannelModifySchema, jwt::Claims, Snowflake};
+use chorus::types::{jwt::Claims, ChannelModifySchema, Snowflake};
 use poem::{
-    delete, get, handler, IntoResponse, post,
-    put,
-    Route, web::{Data, Json, Path},
+    delete, get, handler, post, put,
+    web::{Data, Json, Path},
+    IntoResponse, Route,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/permissions.rs
+++ b/src/api/routes/channels/permissions.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, PermissionOverwrite, PermissionOverwriteType, S
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/pins.rs
+++ b/src/api/routes/channels/pins.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/recipients.rs
+++ b/src/api/routes/channels/recipients.rs
@@ -1,15 +1,15 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{ChannelType, jwt::Claims, Snowflake};
+use chorus::types::{jwt::Claims, ChannelType, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/channels/typing.rs
+++ b/src/api/routes/channels/typing.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
-    Response, web::{Data, Path},
+    web::{Data, Path},
+    IntoResponse, Response,
 };
 use reqwest::StatusCode;
 use sqlx::MySqlPool;

--- a/src/api/routes/channels/webhooks.rs
+++ b/src/api/routes/channels/webhooks.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{CreateWebhookSchema, Snowflake, WebhookType};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/audit_log.rs
+++ b/src/api/routes/guilds/id/audit_log.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{AuditLogObject, GetAuditLogsQuery, PermissionFlags, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/bans.rs
+++ b/src/api/routes/guilds/id/bans.rs
@@ -1,17 +1,17 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    GuildBanBulkCreateSchema, GuildBanCreateSchema, GuildBansQuery, GuildBansSearchQuery,
-    jwt::Claims, Snowflake,
+    jwt::Claims, GuildBanBulkCreateSchema, GuildBanCreateSchema, GuildBansQuery,
+    GuildBansSearchQuery, Snowflake,
 };
 use poem::{
     handler,
-    IntoResponse,
-    Response, web::{Data, Json, Path, Query},
+    web::{Data, Json, Path, Query},
+    IntoResponse, Response,
 };
 use reqwest::StatusCode;
 use sqlx::MySqlPool;

--- a/src/api/routes/guilds/id/channels.rs
+++ b/src/api/routes/guilds/id/channels.rs
@@ -1,16 +1,16 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    ChannelModifySchema, ChannelType, jwt::Claims, ModifyChannelPositionsSchema, Snowflake,
+    jwt::Claims, ChannelModifySchema, ChannelType, ModifyChannelPositionsSchema, Snowflake,
 };
 use poem::{
     handler,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use reqwest::StatusCode;
 use sqlx::MySqlPool;
@@ -54,7 +54,9 @@ pub async fn create_channel(
         false,
         false,
         false,
-        payload.permission_overwrites.unwrap_or_else(std::vec::Vec::new),
+        payload
+            .permission_overwrites
+            .unwrap_or_else(std::vec::Vec::new),
     )
     .await?;
 

--- a/src/api/routes/guilds/id/discovery_requirements.rs
+++ b/src/api/routes/guilds/id/discovery_requirements.rs
@@ -1,16 +1,16 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    GuildDiscoveryHealthScore, GuildDiscoveryRequirements, jwt::Claims, Snowflake,
+    jwt::Claims, GuildDiscoveryHealthScore, GuildDiscoveryRequirements, Snowflake,
 };
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/emoji.rs
+++ b/src/api/routes/guilds/id/emoji.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{EmojiCreateSchema, EmojiModifySchema, jwt::Claims, Snowflake};
+use chorus::types::{jwt::Claims, EmojiCreateSchema, EmojiModifySchema, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use reqwest::StatusCode;
 use sqlx::MySqlPool;

--- a/src/api/routes/guilds/id/invites.rs
+++ b/src/api/routes/guilds/id/invites.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{GetInvitesSchema, jwt::Claims, Snowflake};
+use chorus::types::{jwt::Claims, GetInvitesSchema, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/members/id/mod.rs
+++ b/src/api/routes/guilds/id/members/id/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, ModifyGuildMemberSchema, PermissionFlags, Right
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/members/id/nick.rs
+++ b/src/api/routes/guilds/id/members/id/nick.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, ModifyCurrentGuildMemberSchema, PermissionFlags, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/members/id/roles.rs
+++ b/src/api/routes/guilds/id/members/id/roles.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{PermissionFlags, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Path},
+    web::{Data, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/members/mod.rs
+++ b/src/api/routes/guilds/id/members/mod.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{GuildGetMembersQuery, GuildMembersSearchQuery, jwt::Claims, Snowflake};
+use chorus::types::{jwt::Claims, GuildGetMembersQuery, GuildMembersSearchQuery, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/messages.rs
+++ b/src/api/routes/guilds/id/messages.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{MessageSearchQuery, MessageSearchResponse, PermissionFlags, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use serde_json::json;
 use sqlx::MySqlPool;

--- a/src/api/routes/guilds/id/mod.rs
+++ b/src/api/routes/guilds/id/mod.rs
@@ -1,21 +1,21 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    ChannelType,
-    GuildModifySchema,
-    jwt::Claims, PermissionFlags, PermissionOverwrite, PermissionOverwriteType, Rights,
-    Snowflake, types::guild_configuration::{GuildFeatures, GuildFeaturesList},
+    jwt::Claims,
+    types::guild_configuration::{GuildFeatures, GuildFeaturesList},
+    ChannelType, GuildModifySchema, PermissionFlags, PermissionOverwrite, PermissionOverwriteType,
+    Rights, Snowflake,
 };
 use itertools::Itertools;
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/prune.rs
+++ b/src/api/routes/guilds/id/prune.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{GuildPruneQuerySchema, GuildPruneResult, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path, Query},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/roles/id/member_ids.rs
+++ b/src/api/routes/guilds/id/roles/id/member_ids.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{jwt::Claims, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/roles/id/members.rs
+++ b/src/api/routes/guilds/id/roles/id/members.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, PermissionFlags, Snowflake};
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/roles/id/mod.rs
+++ b/src/api/routes/guilds/id/roles/id/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -8,8 +8,8 @@ use chorus::types::{jwt::Claims, PermissionFlags, RoleCreateModifySchema, Snowfl
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/roles/member_counts.rs
+++ b/src/api/routes/guilds/id/roles/member_counts.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use chorus::types::{jwt::Claims, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/roles/mod.rs
+++ b/src/api/routes/guilds/id/roles/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,8 @@
 use chorus::types::{PermissionFlags, RoleCreateModifySchema, RolePositionUpdateSchema, Snowflake};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/stickers.rs
+++ b/src/api/routes/guilds/id/stickers.rs
@@ -1,17 +1,17 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    GuildCreateStickerSchema, GuildModifyStickerSchema, jwt::Claims, Snowflake, StickerType,
+    jwt::Claims, GuildCreateStickerSchema, GuildModifyStickerSchema, Snowflake, StickerType,
 };
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Multipart, Path},
+    web::{Data, Json, Multipart, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/vanity_url.rs
+++ b/src/api/routes/guilds/id/vanity_url.rs
@@ -1,18 +1,18 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::{
-    GuildCreateVanitySchema, GuildVanityInviteResponse, jwt::Claims,
-    Snowflake, types::guild_configuration::GuildFeatures,
+    jwt::Claims, types::guild_configuration::GuildFeatures, GuildCreateVanitySchema,
+    GuildVanityInviteResponse, Snowflake,
 };
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/voice_states.rs
+++ b/src/api/routes/guilds/id/voice_states.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,8 +9,8 @@ use chrono::Utc;
 use poem::{
     handler,
     http::StatusCode,
-    IntoResponse,
-    Response, web::{Data, Json, Path},
+    web::{Data, Json, Path},
+    IntoResponse, Response,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/id/welcome_screen.rs
+++ b/src/api/routes/guilds/id/welcome_screen.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{GuildModifyWelcomeScreenSchema, jwt::Claims, Snowflake, WelcomeScreenObject};
+use chorus::types::{jwt::Claims, GuildModifyWelcomeScreenSchema, Snowflake, WelcomeScreenObject};
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/mod.rs
+++ b/src/api/routes/guilds/mod.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{GuildCreateSchema, jwt::Claims};
+use chorus::types::{jwt::Claims, GuildCreateSchema};
 use poem::{
-    get, handler, IntoResponse, patch, post,
-    put,
-    Route, web::{Data, Json},
+    get, handler, patch, post, put,
+    web::{Data, Json},
+    IntoResponse, Route,
 };
 use sqlx::MySqlPool;
 

--- a/src/api/routes/guilds/templates.rs
+++ b/src/api/routes/guilds/templates.rs
@@ -1,14 +1,14 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use chorus::types::{GuildTemplateCreateSchema};
+use chorus::types::GuildTemplateCreateSchema;
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json, Path},
+    IntoResponse,
 };
 use reqwest::StatusCode;
 use serde_json::json;

--- a/src/api/routes/health/mod.rs
+++ b/src/api/routes/health/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/invites/mod.rs
+++ b/src/api/routes/invites/mod.rs
@@ -1,12 +1,12 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use chorus::types::jwt::Claims;
-use poem::{get, handler, IntoResponse, Route};
 use poem::web::{Data, Json, Path};
+use poem::{get, handler, IntoResponse, Route};
 use sqlx::MySqlPool;
 
 use crate::database::entities::{Channel, Invite, User};

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/policies/instance/domain.rs
+++ b/src/api/routes/policies/instance/domain.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/policies/instance/limits.rs
+++ b/src/api/routes/policies/instance/limits.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/policies/instance/mod.rs
+++ b/src/api/routes/policies/instance/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/policies/mod.rs
+++ b/src/api/routes/policies/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/policies/stats.rs
+++ b/src/api/routes/policies/stats.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -6,8 +6,8 @@
 
 use poem::{
     handler,
-    IntoResponse,
     web::{Data, Json},
+    IntoResponse,
 };
 use serde_json::json;
 

--- a/src/api/routes/users/me/mod.rs
+++ b/src/api/routes/users/me/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/users/me/settings.rs
+++ b/src/api/routes/users/me/settings.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/api/routes/users/mod.rs
+++ b/src/api/routes/users/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/cdn/mod.rs
+++ b/src/cdn/mod.rs
@@ -1,6 +1,5 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-

--- a/src/database/entities/application.rs
+++ b/src/database/entities/application.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,10 +9,10 @@ use std::ops::{Deref, DerefMut};
 use bitflags::Flags;
 use chorus::types::{ApplicationFlags, Snowflake};
 use serde::{Deserialize, Serialize};
-use sqlx::{MySqlPool};
+use sqlx::MySqlPool;
 
 use crate::{
-    database::entities::{Config, user::User},
+    database::entities::{user::User, Config},
     errors::Error,
 };
 

--- a/src/database/entities/attachment.rs
+++ b/src/database/entities/attachment.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/audit_log.rs
+++ b/src/database/entities/audit_log.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/channel.rs
+++ b/src/database/entities/channel.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -12,11 +12,11 @@ use chorus::types::{
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use sqlx::{MySqlPool, types::Json};
+use sqlx::{types::Json, MySqlPool};
 
 use crate::{
     database::entities::{
-        GuildMember, invite::Invite, message::Message, read_state::ReadState, recipient::Recipient,
+        invite::Invite, message::Message, read_state::ReadState, recipient::Recipient, GuildMember,
         User, Webhook,
     },
     errors::{ChannelError, Error, GuildError, UserError},

--- a/src/database/entities/config.rs
+++ b/src/database/entities/config.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -13,7 +13,7 @@ use serde_json::{Map, Value};
 use sqlx::MySqlPool;
 use tokio::io::AsyncReadExt;
 
-use crate::{errors::Error};
+use crate::errors::Error;
 
 #[derive(Debug, Clone, Default)]
 pub struct Config(chorus::types::ConfigValue);

--- a/src/database/entities/emoji.rs
+++ b/src/database/entities/emoji.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/guild_template.rs
+++ b/src/database/entities/guild_template.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/invite.rs
+++ b/src/database/entities/invite.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/message.rs
+++ b/src/database/entities/message.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/mod.rs
+++ b/src/database/entities/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/read_state.rs
+++ b/src/database/entities/read_state.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/recipient.rs
+++ b/src/database/entities/recipient.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/role.rs
+++ b/src/database/entities/role.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/sticker.rs
+++ b/src/database/entities/sticker.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/template.rs
+++ b/src/database/entities/template.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/user.rs
+++ b/src/database/entities/user.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/user_settings.rs
+++ b/src/database/entities/user_settings.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/voice_state.rs
+++ b/src/database/entities/voice_state.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/entities/webhook.rs
+++ b/src/database/entities/webhook.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,6 +1,5 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,26 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 use clap::Parser;
+use log::LevelFilter;
 use log4rs::{
     append::{
         console::{ConsoleAppender, Target},
         rolling_file::{
             policy::compound::{
-                CompoundPolicy, roll::delete::DeleteRoller, trigger::size::SizeTrigger,
+                roll::delete::DeleteRoller, trigger::size::SizeTrigger, CompoundPolicy,
             },
             RollingFileAppender,
         },
     },
     config::{Appender, Logger, Root},
-    Config,
     encode::pattern::PatternEncoder,
     filter::Filter,
+    Config,
 };
-use log::LevelFilter;
 
 mod api;
 mod cdn;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  *  This Source Code Form is subject to the terms of the Mozilla Public
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at https://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
To keep code formatting consistent across many contributors, I added the [`rusty-hook`](https://crates.io/crates/rusty-hook) crate and configured a git pre-push hook through it, which runs `cargo fmt` before you push. If the code formatting is different than rustfmt would expect, the push aborts, requiring one to run `cargo fmt` manually before pushing.