### PR TITLE
static `DATABASE` and kill for GatewayUser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,45 +10,45 @@ build = "build.rs"
 atomic = "0.6.0"
 base64 = "0.22.1"
 bcrypt = "0.15.1"
-bigdecimal = "0.4.3"
-bitflags = { version = "2.5.0", features = ["serde"] }
-chrono = { version = "0.4.38", features = ["serde"] }
+bigdecimal = "0.4.7"
+bitflags = { version = "2.7.0", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 dotenv = "0.15.0"
-futures = "0.3.30"
+futures = "0.3.31"
 hostname = "0.4.0"
 jsonwebtoken = "9.3.0"
-lazy_static = "1.4.0"
-log = "0.4.21"
+lazy_static = "1.5.0"
+log = "0.4.25"
 log4rs = { version = "1.3.0", features = [
     "rolling_file_appender",
     "compound_policy",
     "size_trigger",
     "gzip",
 ] }
-num-bigint = "0.4.5"
+num-bigint = "0.4.6"
 num-traits = "0.2.19"
-openssl = "0.10.64"
-poem = "3.0.1"
-utoipa = { version = "5.0.0-alpha.0", features = [] }
+openssl = "0.10.68"
+poem = "3.1.6"
+utoipa = { version = "5.3.1", features = [] }
 rand = "0.8.5"
-regex = "1.10.4"
-reqwest = { version = "0.12.5", default-features = false, features = [
+regex = "1.11.1"
+reqwest = { version = "0.12.12", default-features = false, features = [
     "http2",
     "macos-system-configuration",
     "charset",
     "rustls-tls-webpki-roots",
 ] }
-serde = { version = "1.0.203", features = ["derive"] }
-serde_json = { version = "1.0.117", features = ["raw_value"] }
-sqlx = { version = "0.8.2", features = [
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = { version = "1.0.135", features = ["raw_value"] }
+sqlx = { version = "0.8.3", features = [
     "json",
     "chrono",
     "ipnetwork",
     "runtime-tokio-rustls",
     "any",
 ] }
-thiserror = "1.0.61"
-tokio = { version = "1.38.0", features = ["full"] }
+thiserror = "1.0.69"
+tokio = { version = "1.43.0", features = ["full"] }
 sentry = { version = "0.34.0", default-features = false, features = [
     "backtrace",
     "contexts",
@@ -57,7 +57,7 @@ sentry = { version = "0.34.0", default-features = false, features = [
     "reqwest",
     "rustls",
 ] }
-clap = { version = "4.5.4", features = ["derive"] }
+clap = { version = "4.5.26", features = ["derive"] }
 chorus = { features = [
     "backend",
 ], default-features = false, version = "0.18.0" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() {
 
     log::info!(target: "symfonia::db", "Establishing database connection");
     let db = DATABASE
-        .get_or_init(async || {
+        .get_or_init(|| async {
             database::establish_connection()
                 .await
                 .expect("Could not establish a connection to the database")


### PR DESCRIPTION
- adds `static DATABASE: OnceCell<sqlx::PgPool>` as a new, static variable.
    - lots of places and methods require access to information from the database. Prop drilling is exhausting. Accessing a `PgPool` from a `static` context should work.
- adds a `kill` method to `GatewayUser`
    - Disconnect a `GatewayUser` and all their active sessions using the `kill()` method.
- Framework for OS SIGNAL listening
    - Not important right now, will be made into an issue if still relevant later. Accidentally committed this